### PR TITLE
⚙️ ci(workflows): use taiki-e install-action for mdBook (#7)

### DIFF
--- a/.github/workflows/mdbook.yml
+++ b/.github/workflows/mdbook.yml
@@ -32,11 +32,9 @@ jobs:
       MDBOOK_VERSION: 0.4.52
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
-      - name: Install mdBook
-        run: |
-          curl --proto '=https' --tlsv1.2 https://sh.rustup.rs -sSf -y | sh
-          rustup update
-          cargo install --version ${MDBOOK_VERSION} mdbook
+      - uses: taiki-e/install-action@c070f87102a1c75b3183910f391c1cb887fe13c8 # v2.77.6
+        with:
+          tool: mdbook@${MDBOOK_VERSION}
       - name: Setup Pages
         id: pages
         uses: actions/configure-pages@45bfe0192ca1faeb007ade9deae92b16b8254a0d # v6.0.0


### PR DESCRIPTION
Replace manual Rust toolchain setup and cargo install with taiki-e/install-action to install mdbook at the specified version, reducing steps and improving workflow reliability.

Signed-off-by: Mao-Kai Lan <45162039+mukappalambda@users.noreply.github.com>
