### PR TITLE
🔧 ci(workflows): switch mdBook install to mise in GitHub Actions (#28)

### DIFF
--- a/.github/workflows/mdbook.yml
+++ b/.github/workflows/mdbook.yml
@@ -34,7 +34,8 @@ jobs:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
       - uses: taiki-e/install-action@c070f87102a1c75b3183910f391c1cb887fe13c8 # v2.77.6
         with:
-          tool: mdbook@${MDBOOK_VERSION}
+          tool: mise
+      - run: mise install
       - name: Setup Pages
         id: pages
         uses: actions/configure-pages@45bfe0192ca1faeb007ade9deae92b16b8254a0d # v6.0.0


### PR DESCRIPTION
Replace taiki-e install-action mdbook usage with mise, and run `mise install` to provision required tools before Pages setup in the mdbook workflow.

Signed-off-by: Mao-Kai Lan <45162039+mukappalambda@users.noreply.github.com>
