### PR TITLE
🐛 fix(ci): use mise-resolved mdbook path in workflow (#30)

### DIFF
--- a/.github/workflows/mdbook.yml
+++ b/.github/workflows/mdbook.yml
@@ -40,7 +40,7 @@ jobs:
         id: pages
         uses: actions/configure-pages@45bfe0192ca1faeb007ade9deae92b16b8254a0d # v6.0.0
       - name: Build with mdBook
-        run: mdbook build
+        run: $(mise which mdbook) build
       - name: Upload artifact
         uses: actions/upload-pages-artifact@fc324d3547104276b827a68afc52ff2a11cc49c9 # v5.0.0
         with:


### PR DESCRIPTION
Replace direct mdbook invocation with `$(mise which mdbook)` to prevent “command not found” in GitHub Actions and ensure the correct binary is used during Pages builds.

Signed-off-by: Mao-Kai Lan <45162039+mukappalambda@users.noreply.github.com>
